### PR TITLE
Input fix: onKeyPress is not a function

### DIFF
--- a/lib/form.js
+++ b/lib/form.js
@@ -5,11 +5,13 @@ function noop() {}
 
 export class Input extends Component {
   static propTypes = {
+    onKeyPress: PropTypes.func,
     onChange: PropTypes.func,
     onEnter: PropTypes.func
   }
 
   static defaultProps = {
+    onKeyPress: noop,
     onChange: noop,
     onEnter: noop
   }


### PR DESCRIPTION
使用 Input 组件未设定 `onKeyPress` 方法时，每次键盘输入都会报 `onKeyPress is not a function` 错误